### PR TITLE
Add support for getting/setting build type parameters

### DIFF
--- a/pyteamcity/future/build_type.py
+++ b/pyteamcity/future/build_type.py
@@ -173,7 +173,8 @@ class BuildType(object):
             f'/parameters/{parameter_name}'])
         res = self.teamcity.session.put(
             url=url,
-            headers={'Content-Type': 'text/plain'},
+            headers={'Content-Type': 'text/plain',
+                     'Accept': 'text/plain'},
             data=str(parameter_value))
         raise_on_status(res)
 


### PR DESCRIPTION
Necessary for the leapfrog release automation scripts to modify build configuration template parameters