### PR TITLE
LF-44545 pass query set to build constructor when getting dependencies

### DIFF
--- a/pyteamcity/future/build.py
+++ b/pyteamcity/future/build.py
@@ -209,7 +209,8 @@ class Build(object):
         raise_on_status(res)
 
         queued_build_data = res.json()
-        return [Build.from_dict(build_dict, teamcity=self.teamcity) for build_dict in queued_build_data['build']]
+        return [Build.from_dict(build_dict, build_query_set=self.build_query_set, teamcity=self.teamcity)
+                for build_dict in queued_build_data['build']]
 
 
 class BuildQuerySet(QuerySet):


### PR DESCRIPTION
Fixed bug where the snapshot dependency 'Build' instances were initialised without reference to the build query set instance, making it impossible to call instance methods which query the server.